### PR TITLE
only retrieve farms on initial load in EditFarmsFragment

### DIFF
--- a/app/src/main/java/com/pickledgames/stardewvalleyguide/fragments/EditFarmsFragment.kt
+++ b/app/src/main/java/com/pickledgames/stardewvalleyguide/fragments/EditFarmsFragment.kt
@@ -60,24 +60,32 @@ class EditFarmsFragment : InnerBaseFragment() {
     }
 
     private fun setup() {
-        val disposable = farmRepository.getFarms()
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { f ->
-                    farms.addAll(f)
-                    edit_farms_recycler_view.visibility = View.VISIBLE
-                    loading_container.visibility = View.GONE
-                    edit_farms_recycler_view.adapter = FarmsAdapter(farms, activity as MainActivity)
-                    edit_farms_recycler_view.layoutManager = LinearLayoutManager(activity)
-                    edit_farms_recycler_view.addItemDecoration(DividerItemDecoration(activity, DividerItemDecoration.VERTICAL))
-                }
+        if (farms.isNotEmpty()) {
+            setupAdapter()
+        } else {
+            val disposable = farmRepository.getFarms()
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe { f ->
+                        farms.addAll(f)
+                        setupAdapter()
+                    }
 
-        compositeDisposable.add(disposable)
+            compositeDisposable.add(disposable)
+        }
+    }
+
+    private fun setupAdapter() {
+        edit_farms_recycler_view.visibility = View.VISIBLE
+        loading_container.visibility = View.GONE
+        edit_farms_recycler_view.adapter = FarmsAdapter(farms, activity as MainActivity)
+        edit_farms_recycler_view.layoutManager = LinearLayoutManager(activity)
+        edit_farms_recycler_view.addItemDecoration(DividerItemDecoration(activity, DividerItemDecoration.VERTICAL))
     }
 
     fun updateFarm(farm: Farm?, position: Int) {
         if (farm == null && farms.size == 1) {
-            Toast.makeText(activity, R.string.delete_error_message, Toast.LENGTH_SHORT).show()
+            Toast.makeText(activity, R.string.delete_error_message, Toast.LENGTH_LONG).show()
         } else if (farm == null) {
             val deletedFarm = farms.removeAt(position)
             edit_farms_recycler_view.adapter?.notifyItemRemoved(position)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,7 +25,7 @@
     <string name="edit_farms">Edit Farms</string>
     <string name="farm_type">Farm Type</string>
     <string name="bundle_quantity_completed_template">%d/%d</string>
-    <string name="delete_error_message">Delete aborted, must have at least 1 farm.</string>
+    <string name="delete_error_message">Delete not allowed, must have at least 1 farm.</string>
     <string name="fall">Fall</string>
     <string name="winter">Winter</string>
     <string name="spring">Spring</string>


### PR DESCRIPTION
@jetmax25 
This fixes a bug where the number of farms in the Edit Farms page increases every time you come back into the page.